### PR TITLE
fix: trimming agent url input

### DIFF
--- a/frontend/src/script.ts
+++ b/frontend/src/script.ts
@@ -101,7 +101,7 @@ document.addEventListener('DOMContentLoaded', () => {
     };
     
     connectBtn.addEventListener('click', async () => {
-        let url = agentUrlInput.value;
+        let url = agentUrlInput.value.trim();
         if (!url) { return alert('Please enter an agent URL.'); }
         if (!/^https?:\/\//i.test(url)) { url = 'http://' + url; }
 


### PR DESCRIPTION
Trimmed agent URL input using `.trim`() to prevent errors caused by leading/trailing whitespace when pasting URLs

Before:
![image](https://github.com/user-attachments/assets/b67eea0d-a962-4717-8abe-4d1c684ec18f)

After

![image](https://github.com/user-attachments/assets/7cdc8c36-585b-4711-beb5-4898b2f66c53)

---

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [x] Appropriate docs were updated (if necessary)

