### PR TITLE
fix: Align nox Python version with project requirements

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,7 +23,7 @@ import subprocess
 import nox
 
 
-DEFAULT_PYTHON_VERSION = '3.10'
+DEFAULT_PYTHON_VERSION = '3.12'
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 


### PR DESCRIPTION
# Description

## Fix: Align nox Python version with project requirements

### Problem
- `pyproject.toml` specifies `requires-python = ">=3.12"`
- `noxfile.py` was configured with `DEFAULT_PYTHON_VERSION = '3.10'`
- This mismatch caused `nox -s format` to fail with interpreter compatibility errors

### Solution
- Updated `DEFAULT_PYTHON_VERSION` from `'3.10'` to `'3.12'` in `noxfile.py`
- Ensures consistency between project Python requirements and nox configuration

---

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

